### PR TITLE
feat: implement DatePicker Step 1 - Date Picker

### DIFF
--- a/src/components/AhaDatePicker/AhaDatePicker.tsx
+++ b/src/components/AhaDatePicker/AhaDatePicker.tsx
@@ -1,5 +1,6 @@
 import type { ReactElement } from 'react'
 import { useCallback, useState } from 'react'
+import type { DateValidationError } from '@mui/x-date-pickers'
 import { DatePicker } from '@mui/x-date-pickers'
 import type { Dayjs } from 'dayjs'
 import {
@@ -9,6 +10,8 @@ import {
 	slotPropsTextFieldSx
 } from './stylesDatePicker'
 import type { DatePickerProps } from '@mui/x-date-pickers/DatePicker/DatePicker.types'
+import AhaPickersDay from './AhaPickersDay'
+import type { PickerChangeHandlerContext } from '@mui/x-date-pickers/internals/hooks/usePicker/usePickerValue.types'
 
 const dayOfWeekFormatter = (d: string): string => d
 
@@ -39,6 +42,7 @@ const dayOfWeekFormatter = (d: string): string => d
  *
  */
 export default function AhaDatePicker({
+	onChange,
 	slotProps,
 	...props
 }: DatePickerProps<Dayjs> & React.RefAttributes<HTMLDivElement>): ReactElement {
@@ -53,6 +57,18 @@ export default function AhaDatePicker({
 	} = slotProps ?? {}
 
 	const [isOpen, setIsOpen] = useState(false)
+	const [date, setDate] = useState<Dayjs | null>()
+
+	const handleOnChange = useCallback(
+		(
+			value: Dayjs | null,
+			context: PickerChangeHandlerContext<DateValidationError>
+		): void => {
+			setDate(value)
+			onChange?.(value, context)
+		},
+		[onChange]
+	)
 
 	const handlePopperClose = useCallback(() => {
 		setIsOpen(false)
@@ -73,8 +89,18 @@ export default function AhaDatePicker({
 			open={isOpen}
 			onClose={handlePopperClose}
 			//
+			// to customize the color of previous selected day, we need to use onChange callback to record the value,
+			// then pass it into AhaPickersDay component
+			onChange={handleOnChange}
+			slots={{
+				day: AhaPickersDay
+			}}
+			//
 			// customize children
 			slotProps={{
+				day: {
+					value: date?.valueOf()
+				},
 				popper: {
 					sx: slotPropsPopperSx,
 					...slotPropsPopper

--- a/src/components/AhaDatePicker/AhaDatePicker.tsx
+++ b/src/components/AhaDatePicker/AhaDatePicker.tsx
@@ -1,0 +1,106 @@
+import type { ReactElement } from 'react'
+import { useCallback, useState } from 'react'
+import { DatePicker } from '@mui/x-date-pickers'
+import type { Dayjs } from 'dayjs'
+import {
+	slotPropsActionBarSx,
+	slotPropsInputAdornmentSx,
+	slotPropsPopperSx,
+	slotPropsTextFieldSx
+} from './stylesDatePicker'
+import type { DatePickerProps } from '@mui/x-date-pickers/DatePicker/DatePicker.types'
+
+const dayOfWeekFormatter = (d: string): string => d
+
+/**
+ * Aha Style Date Picker
+ *
+ * A MuiDatePicker use following structure
+ * (reference: https://mui.com/x/react-date-pickers/custom-layout/)
+ *
+ * Following diagram demo where we customize (*)
+ *
+ * ---------------------------------    DatePicker
+ * | 06 / 23 / 2023                |			Picker
+ * --------------------------------          Field
+ *                                             TextField
+ *                                                 input		(* hide inputAdornment)
+ * -------------------------------        Popper
+ * | SELECT DATE                 |          Toolbar
+ * | Jun, 2023                   |          								(* change format)
+ * | <        June 2023       >  |          Header					(* change arrow position)
+ * |														 |						Switcher
+ * | Su  Mo  Tu  We  Th  Fr  Sa  |
+ * | 28  29  30  31  1  2  3  4  |					Day							(* change style)
+ * | 5  6  7  8  9  10  11  12   |
+ * | ....                        |
+ * |            Cancel     OK    |					ActionBar				(* change style)
+ * -------------------------------
+ *
+ */
+export default function AhaDatePicker({
+	slotProps,
+	...props
+}: DatePickerProps<Dayjs> & React.RefAttributes<HTMLDivElement>): ReactElement {
+	// extract following props in case user pass them in
+	const {
+		popper: slotPropsPopper,
+		textField: slotPropsTextField,
+		inputAdornment: slotPropsInputAdornment,
+		toolbar: slotPropsToolbar,
+		actionBar: slotPropsActionBar,
+		...restSlotProps
+	} = slotProps ?? {}
+
+	const [isOpen, setIsOpen] = useState(false)
+
+	const handlePopperClose = useCallback(() => {
+		setIsOpen(false)
+	}, [])
+
+	const handleTextFieldClick = useCallback(() => {
+		setIsOpen(true)
+	}, [])
+
+	return (
+		<DatePicker
+			// meet style
+			showDaysOutsideCurrentMonth
+			dayOfWeekFormatter={dayOfWeekFormatter}
+			closeOnSelect={false}
+			//
+			// customize open behavior by focusing on TextField
+			open={isOpen}
+			onClose={handlePopperClose}
+			//
+			// customize children
+			slotProps={{
+				popper: {
+					sx: slotPropsPopperSx,
+					...slotPropsPopper
+				},
+				textField: {
+					sx: slotPropsTextFieldSx,
+					onClick: handleTextFieldClick, // XXX: we might need to support user pass textField.onClick prop in
+					...slotPropsTextField
+				},
+				inputAdornment: {
+					sx: slotPropsInputAdornmentSx,
+					...slotPropsInputAdornment
+				},
+				toolbar: {
+					hidden: false, // in MUI default setting, toolbar only appear in mobile view
+					toolbarFormat: 'MMM, YYYY',
+					...slotPropsToolbar
+				},
+				actionBar: {
+					actions: ['cancel', 'accept'],
+					sx: slotPropsActionBarSx,
+					...slotPropsActionBar
+				},
+				...restSlotProps
+			}}
+			{...props}
+		/>
+	)
+}

--- a/src/components/AhaDatePicker/AhaPickersDay.tsx
+++ b/src/components/AhaDatePicker/AhaPickersDay.tsx
@@ -1,0 +1,31 @@
+import type { PickersDayProps } from '@mui/x-date-pickers'
+import { PickersDay } from '@mui/x-date-pickers'
+import type { Dayjs } from 'dayjs'
+import type { ReactElement } from 'react'
+import { useEffect, useRef } from 'react'
+import { previousSelectedCssClass } from './stylesDatePicker'
+
+export default function AhaPickersDay({
+	day,
+	className,
+	value,
+	...props
+}: PickersDayProps<Dayjs>): ReactElement {
+	const previousValue = useRef<number | undefined>()
+
+	useEffect(() => {
+		previousValue.current = value as number | undefined
+	}, [value])
+
+	const isPreviousSelected = previousValue.current === day.valueOf()
+
+	return (
+		<PickersDay
+			day={day}
+			className={`${className ?? ''} ${
+				isPreviousSelected ? previousSelectedCssClass : ''
+			}`}
+			{...props}
+		/>
+	)
+}

--- a/src/components/AhaDatePicker/index.ts
+++ b/src/components/AhaDatePicker/index.ts
@@ -1,0 +1,2 @@
+// eslint-disable-next-line import/prefer-default-export
+export { default as AhaDatePicker } from './AhaDatePicker'

--- a/src/components/AhaDatePicker/stylesDatePicker.ts
+++ b/src/components/AhaDatePicker/stylesDatePicker.ts
@@ -30,6 +30,8 @@
  * │   └── div(data-testid="sentinelEnd")
  */
 
+export const previousSelectedCssClass = 'App-Previous-Selected'
+
 export const slotPropsPopperSx = {
 	'.MuiPaper-root': {
 		backgroundImage: 'none', // MuiPaper has default gradient, so we need to override it
@@ -83,9 +85,25 @@ export const slotPropsPopperSx = {
 						backgroundColor: '#FFFFFF',
 						color: '#1B1B1B'
 					},
+					':focus': {
+						backgroundColor: '#1B1B1B'
+					},
 
 					'&.MuiPickersDay-today': {
-						borderColor: '#00A3FF'
+						border: 'none'
+					},
+
+					'&.Mui-selected': {
+						backgroundColor: '#00A3FF',
+						color: '#FFFFFF'
+					},
+
+					'&.MuiPickersDay-dayOutsideMonth': {
+						color: '#5D5D5D'
+					},
+
+					[`&.${previousSelectedCssClass}`]: {
+						border: '1px solid #00A3FF'
 					}
 				}
 			}

--- a/src/components/AhaDatePicker/stylesDatePicker.ts
+++ b/src/components/AhaDatePicker/stylesDatePicker.ts
@@ -1,0 +1,125 @@
+/**
+ *  CSS Structure overview
+ *
+ * ├── div(MuiPaper-root)
+ * │   ├── div(MuiPickersPopper-paper)
+ * │   │   ├── div(MuiPickersLayout-root)
+ * │   │   │   ├── div(MuiPickersLayout-toolbar)
+ * │   │   │   │   ├── span - Select date
+ * │   │   │   │   └── div(MuiPickersToolbar-content)
+ * │   │   │   │       └── h4 - Jun, 2023
+ * │   │   │   ├─ div(MuiPickersLayout-contentWrapper)
+ * │   │   │   │    └─ div(MuiDateCalendar-root)
+ * │   │   │   │       ├── div(MuiPickersCalendarHeader-root)
+ * │   │   │   │       │   ├── div(MuiPickersCalendarHeader-labelContainer)
+ * │   │   │   │       │   │   ├── div - June 2023
+ * │   │   │   │       │   │   └── button - switchViewButton
+ * │   │   │   │       │   └── div(MuiPickersArrowSwitcher-root)
+ * │   │   │   │       │        ├── button - ArrowLeftIcon
+ * │   │   │   │       │        └── button - ArrowRightIcon
+ * │   │   │   │       └── div(MuiPickersFadeTransitionGroup-root)
+ * │   │   │   │           └── div
+ * │   │   │   │               └── div
+ * │   │   │   │                   └── div(role="grid")
+ * │   │   │   │                       └── div(MuiDayCalendar-weekContainer)
+ * │   │   │   │                           ├── button(MuiPickersDay) - 28
+ * │   │   │   │                           └── button(MuiPickersDay) - 29
+ * │   │   │   └── div(MuiDialogActions-root)
+ * │   │   │           ├── button - Cancel
+ * │   │   │           └── button - OK
+ * │   └── div(data-testid="sentinelEnd")
+ */
+
+export const slotPropsPopperSx = {
+	'.MuiPaper-root': {
+		backgroundImage: 'none', // MuiPaper has default gradient, so we need to override it
+		backgroundColor: '#1B1B1B',
+
+		// meet style
+		'.MuiPickersLayout-toolbar': {
+			paddingTop: '8px',
+			paddingBottom: '6px',
+			paddingLeft: '26px',
+			paddingRight: '24px'
+		},
+
+		'.MuiPickersCalendarHeader-root': {
+			// make label (June 2023) display in the center (default is on the left)
+			justifyContent: 'center',
+			'.MuiPickersCalendarHeader-labelContainer': {
+				margin: 0,
+				// eslint-disable-next-line @typescript-eslint/no-magic-numbers
+				zIndex: 1 // HACK: greater than the zIndex of the arrowSwitcher, so this one is clickable to switch view
+			},
+
+			// make arrow left and right on each side (default is on the right side)
+			'.MuiPickersArrowSwitcher-root': {
+				position: 'absolute',
+				left: '0',
+				width: '100%',
+				display: 'flex',
+				justifyContent: 'space-between',
+				paddingLeft: '5px',
+				paddingRight: '5px',
+				zIndex: 0 // HACK: smaller than the zIndex of the labelContainer, so labelContainer is clickable to switch view
+			},
+
+			// in our design, we don't need this
+			'.MuiPickersCalendarHeader-switchViewButton': {
+				display: 'none'
+			}
+		},
+
+		'.MuiDayCalendar-slideTransition': {
+			minHeight: '220px',
+
+			'.MuiDayCalendar-weekContainer': {
+				margin: '0',
+
+				'.MuiPickersDay-root': {
+					fontSize: '14px',
+
+					':hover': {
+						backgroundColor: '#FFFFFF',
+						color: '#1B1B1B'
+					},
+
+					'&.MuiPickersDay-today': {
+						borderColor: '#00A3FF'
+					}
+				}
+			}
+		},
+
+		'.MuiPickersLayout-actionBar': {
+			paddingTop: '5px',
+			paddingBottom: '12px',
+
+			// make action button with longer distance
+			'&>:not(:first-of-type)': {
+				marginLeft: '40px'
+			}
+		}
+	}
+}
+
+export const slotPropsTextFieldSx = {
+	'.MuiOutlinedInput-root': {
+		'&.Mui-focused fieldset': {
+			border: '3px solid #FFFFFF'
+		}
+	}
+}
+
+export const slotPropsInputAdornmentSx = {
+	'&': {
+		visibility: 'hidden' // HACK: this is the calendar icon, although we can use disableOpenPicker to hide it, but that will make the calendar lose its position
+	}
+}
+
+export const slotPropsActionBarSx = {
+	button: {
+		textTransform: 'none',
+		color: '#FFFFFF'
+	}
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,6 +5,8 @@ import { registerSW } from 'virtual:pwa-register'
 import './index.css'
 import muiTheme from './muiTheme'
 import { ThemeProvider as MuiThemeProvider } from '@mui/material'
+import { LocalizationProvider } from '@mui/x-date-pickers'
+import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs'
 
 registerSW()
 
@@ -14,7 +16,9 @@ if (container) {
 	root.render(
 		<StrictMode>
 			<MuiThemeProvider theme={muiTheme}>
-				<App />
+				<LocalizationProvider dateAdapter={AdapterDayjs}>
+					<App />
+				</LocalizationProvider>
 			</MuiThemeProvider>
 		</StrictMode>
 	)

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,8 +1,16 @@
 import type { ReactElement } from 'react'
+import { useCallback, useState } from 'react'
 import Head from '../components/Common/Head'
-import PasswordTextField from '../components/PasswordTextField/PasswordTextField'
+import { PasswordTextField } from '../components/PasswordTextField'
+import { AhaDatePicker } from '../components/AhaDatePicker'
+import type { Dayjs } from 'dayjs'
 
 export default function HomePage(): ReactElement {
+	const [datePickerValue, setDatePickerValue] = useState<Dayjs | null>()
+	const handleDatePickerValueChange = useCallback((value: Dayjs | null) => {
+		setDatePickerValue(value)
+	}, [])
+
 	return (
 		<>
 			<Head title='AHA Front-End Assignment Exam 1' />
@@ -10,8 +18,27 @@ export default function HomePage(): ReactElement {
 				<div className='flex justify-center p-2'>
 					<h1 className='text-2xl'>AHA Front-End Assignment Exam 1</h1>
 				</div>
-				<div className='mt-10 flex w-1/2 justify-center'>
-					<PasswordTextField />
+				<div className='flex'>
+					<div className='mt-10 flex h-screen w-1/2 justify-center'>
+						<div>
+							<h2 className='m-10 pr-8 text-center text-xl'>Password Input</h2>
+							<PasswordTextField />
+						</div>
+					</div>
+					<div className='mt-10 flex h-screen w-1/2 justify-center'>
+						<div>
+							<h2 className='m-10 pr-8 text-center text-xl'>Date Picker</h2>
+							<AhaDatePicker
+								defaultValue={datePickerValue}
+								onChange={handleDatePickerValueChange}
+								slotProps={{
+									textField: {
+										label: 'Birthday'
+									}
+								}}
+							/>
+						</div>
+					</div>
 				</div>
 			</div>
 		</>


### PR DESCRIPTION
# Context

In this pull request, I start to implement Aha styled Date Picker, which I choose to leverage MUI-X 's DatePicker to customize, this pull request is the step1, the year picker part I put in step2

# Changes

1. customize the ui 
2. customize the ux  (click textField to open the date picker instead of click calendar icon)
3. add the styled of previous selected date (a281ab99139d6a7e14794bbbe2bc231c6f1193e3), which is a little bit tricky, because MUI doesn't support this feature, so I use a customized `AhaPickersDay`  to achieve this

# Screenshot 


https://github.com/benqqqq/aha-fe-assignment/assets/11547758/0bb6ab12-3d82-482b-9d10-a94bf3328c3d



# To be discussion

Because we use "input click" event to open the popover, when click on the input, there will be a slight flicker, it might look strange. But if we still need to support client to type value directly on the input box, it make take some time to find the better ux.
