### PR TITLE
feat: implement DatePicker Step 2 - yearCalendar 

### DIFF
--- a/src/components/AhaDatePicker/AhaDatePicker.tsx
+++ b/src/components/AhaDatePicker/AhaDatePicker.tsx
@@ -1,8 +1,13 @@
-import type { ReactElement } from 'react'
+import type { ReactElement, ReactNode } from 'react'
 import { useCallback, useState } from 'react'
-import type { DateValidationError } from '@mui/x-date-pickers'
+import type {
+	DateValidationError,
+	DateView,
+	DateViewRendererProps
+} from '@mui/x-date-pickers'
 import { DatePicker } from '@mui/x-date-pickers'
 import type { Dayjs } from 'dayjs'
+import AhaYearCalendar from './AhaYearCalendar'
 import {
 	slotPropsActionBarSx,
 	slotPropsInputAdornmentSx,
@@ -14,6 +19,10 @@ import AhaPickersDay from './AhaPickersDay'
 import type { PickerChangeHandlerContext } from '@mui/x-date-pickers/internals/hooks/usePicker/usePickerValue.types'
 
 const dayOfWeekFormatter = (d: string): string => d
+
+const renderYearViewCalendar = (
+	args: DateViewRendererProps<Dayjs, DateView>
+): ReactNode => <AhaYearCalendar {...args} />
 
 /**
  * Aha Style Date Picker
@@ -42,6 +51,7 @@ const dayOfWeekFormatter = (d: string): string => d
  *
  */
 export default function AhaDatePicker({
+	viewRenderers,
 	onChange,
 	slotProps,
 	...props
@@ -84,6 +94,12 @@ export default function AhaDatePicker({
 			showDaysOutsideCurrentMonth
 			dayOfWeekFormatter={dayOfWeekFormatter}
 			closeOnSelect={false}
+			//
+			// customized year calendar
+			viewRenderers={{
+				year: renderYearViewCalendar,
+				...viewRenderers
+			}}
 			//
 			// customize open behavior by focusing on TextField
 			open={isOpen}

--- a/src/components/AhaDatePicker/AhaDatePicker.tsx
+++ b/src/components/AhaDatePicker/AhaDatePicker.tsx
@@ -1,5 +1,6 @@
 import type { ReactElement } from 'react'
 import { useCallback, useState } from 'react'
+import type { DateValidationError } from '@mui/x-date-pickers'
 import { DatePicker } from '@mui/x-date-pickers'
 import type { Dayjs } from 'dayjs'
 import {
@@ -9,6 +10,8 @@ import {
 	slotPropsTextFieldSx
 } from './stylesDatePicker'
 import type { DatePickerProps } from '@mui/x-date-pickers/DatePicker/DatePicker.types'
+import AhaPickersDay from './AhaPickersDay'
+import type { PickerChangeHandlerContext } from '@mui/x-date-pickers/internals/hooks/usePicker/usePickerValue.types'
 
 const dayOfWeekFormatter = (d: string): string => d
 
@@ -39,6 +42,7 @@ const dayOfWeekFormatter = (d: string): string => d
  *
  */
 export default function AhaDatePicker({
+	onChange,
 	slotProps,
 	...props
 }: DatePickerProps<Dayjs> & React.RefAttributes<HTMLDivElement>): ReactElement {
@@ -53,6 +57,18 @@ export default function AhaDatePicker({
 	} = slotProps ?? {}
 
 	const [isOpen, setIsOpen] = useState(false)
+	const [date, setDate] = useState<Dayjs | null>()
+
+	const handleOnChange = useCallback(
+		(
+			value: Dayjs | null,
+			context: PickerChangeHandlerContext<DateValidationError>
+		): void => {
+			setDate(value)
+			onChange?.(value, context)
+		},
+		[onChange]
+	)
 
 	const handlePopperClose = useCallback(() => {
 		setIsOpen(false)
@@ -73,8 +89,18 @@ export default function AhaDatePicker({
 			open={isOpen}
 			onClose={handlePopperClose}
 			//
+			// to customize the color of previous selected day, we need to use onChange callback to record the value,
+			// then pass it into AhaPickersDay component
+			onChange={handleOnChange}
+			slots={{
+				day: AhaPickersDay
+			}}
+			//
 			// customize children
 			slotProps={{
+				day: {
+					value: date?.valueOf()
+				},
 				popper: {
 					sx: slotPropsPopperSx,
 					...slotPropsPopper

--- a/src/components/AhaDatePicker/AhaDatePicker.tsx
+++ b/src/components/AhaDatePicker/AhaDatePicker.tsx
@@ -1,0 +1,106 @@
+import type { ReactElement } from 'react'
+import { useCallback, useState } from 'react'
+import { DatePicker } from '@mui/x-date-pickers'
+import type { Dayjs } from 'dayjs'
+import {
+	slotPropsActionBarSx,
+	slotPropsInputAdornmentSx,
+	slotPropsPopperSx,
+	slotPropsTextFieldSx
+} from './stylesDatePicker'
+import type { DatePickerProps } from '@mui/x-date-pickers/DatePicker/DatePicker.types'
+
+const dayOfWeekFormatter = (d: string): string => d
+
+/**
+ * Aha Style Date Picker
+ *
+ * A MuiDatePicker use following structure
+ * (reference: https://mui.com/x/react-date-pickers/custom-layout/)
+ *
+ * Following diagram demo where we customize (*)
+ *
+ * ---------------------------------    DatePicker
+ * | 06 / 23 / 2023                |			Picker
+ * --------------------------------          Field
+ *                                             TextField
+ *                                                 input		(* hide inputAdornment)
+ * -------------------------------        Popper
+ * | SELECT DATE                 |          Toolbar
+ * | Jun, 2023                   |          								(* change format)
+ * | <        June 2023       >  |          Header					(* change arrow position)
+ * |														 |						Switcher
+ * | Su  Mo  Tu  We  Th  Fr  Sa  |
+ * | 28  29  30  31  1  2  3  4  |					Day							(* change style)
+ * | 5  6  7  8  9  10  11  12   |
+ * | ....                        |
+ * |            Cancel     OK    |					ActionBar				(* change style)
+ * -------------------------------
+ *
+ */
+export default function AhaDatePicker({
+	slotProps,
+	...props
+}: DatePickerProps<Dayjs> & React.RefAttributes<HTMLDivElement>): ReactElement {
+	// extract following props in case user pass them in
+	const {
+		popper: slotPropsPopper,
+		textField: slotPropsTextField,
+		inputAdornment: slotPropsInputAdornment,
+		toolbar: slotPropsToolbar,
+		actionBar: slotPropsActionBar,
+		...restSlotProps
+	} = slotProps ?? {}
+
+	const [isOpen, setIsOpen] = useState(false)
+
+	const handlePopperClose = useCallback(() => {
+		setIsOpen(false)
+	}, [])
+
+	const handleTextFieldClick = useCallback(() => {
+		setIsOpen(true)
+	}, [])
+
+	return (
+		<DatePicker
+			// meet style
+			showDaysOutsideCurrentMonth
+			dayOfWeekFormatter={dayOfWeekFormatter}
+			closeOnSelect={false}
+			//
+			// customize open behavior by focusing on TextField
+			open={isOpen}
+			onClose={handlePopperClose}
+			//
+			// customize children
+			slotProps={{
+				popper: {
+					sx: slotPropsPopperSx,
+					...slotPropsPopper
+				},
+				textField: {
+					sx: slotPropsTextFieldSx,
+					onClick: handleTextFieldClick, // XXX: we might need to support user pass textField.onClick prop in
+					...slotPropsTextField
+				},
+				inputAdornment: {
+					sx: slotPropsInputAdornmentSx,
+					...slotPropsInputAdornment
+				},
+				toolbar: {
+					hidden: false, // in MUI default setting, toolbar only appear in mobile view
+					toolbarFormat: 'MMM, YYYY',
+					...slotPropsToolbar
+				},
+				actionBar: {
+					actions: ['cancel', 'accept'],
+					sx: slotPropsActionBarSx,
+					...slotPropsActionBar
+				},
+				...restSlotProps
+			}}
+			{...props}
+		/>
+	)
+}

--- a/src/components/AhaDatePicker/AhaPickersDay.tsx
+++ b/src/components/AhaDatePicker/AhaPickersDay.tsx
@@ -1,0 +1,31 @@
+import type { PickersDayProps } from '@mui/x-date-pickers'
+import { PickersDay } from '@mui/x-date-pickers'
+import type { Dayjs } from 'dayjs'
+import type { ReactElement } from 'react'
+import { useEffect, useRef } from 'react'
+import { previousSelectedCssClass } from './stylesDatePicker'
+
+export default function AhaPickersDay({
+	day,
+	className,
+	value,
+	...props
+}: PickersDayProps<Dayjs>): ReactElement {
+	const previousValue = useRef<number | undefined>()
+
+	useEffect(() => {
+		previousValue.current = value as number | undefined
+	}, [value])
+
+	const isPreviousSelected = previousValue.current === day.valueOf()
+
+	return (
+		<PickersDay
+			day={day}
+			className={`${className ?? ''} ${
+				isPreviousSelected ? previousSelectedCssClass : ''
+			}`}
+			{...props}
+		/>
+	)
+}

--- a/src/components/AhaDatePicker/AhaYearCalendar.tsx
+++ b/src/components/AhaDatePicker/AhaYearCalendar.tsx
@@ -1,0 +1,108 @@
+import type { ReactElement } from 'react'
+import { useCallback, useMemo, useState } from 'react'
+import { PickersArrowSwitcher } from '@mui/x-date-pickers/internals'
+import type { DateView, DateViewRendererProps } from '@mui/x-date-pickers'
+import { renderDateViewCalendar } from '@mui/x-date-pickers'
+import type { Dayjs } from 'dayjs'
+import dayjs from 'dayjs'
+import {
+	slotPropsNextIconButtonSx,
+	slotPropsPreviousIconButtonSx,
+	yearPickersArrowSwitcherStyle,
+	yearViewSx
+} from './stylesYearPicker'
+import {
+	calculatePageAttribute,
+	calculateWhichPageShouldDisplay,
+	yearToDayjsInput
+} from './utils'
+
+const ONE = 1 // XXX: although this looks unnecessary, we need this to prevent 'no-magic-number' eslint rule
+
+/**
+ * Aha Style Year Picker
+ *
+ * This component need to customize the year scroll behavior,
+ * in MUI-X DatePicker, it use a scrollbar to select all years,
+ * but in Aha Style, it use arrow switcher to change the page of different years,
+ * so we need to paginate the years by ourselves :
+ * 1. create a function to calculate the page number and insert "min year" and "max year" to make every page
+ * 2. create a new ArrowSwitcher component to control next page and previous page
+ *
+ * @param minDate
+ * @param maxDate
+ * @param value
+ * @param props
+ */
+export default function AhaYearCalendar({
+	minDate,
+	maxDate,
+	value,
+	...props
+}: DateViewRendererProps<Dayjs, DateView>): ReactElement {
+	const [page, setPage] = useState(
+		calculateWhichPageShouldDisplay({
+			valueYear: value?.year(),
+			todayYear: dayjs().year(),
+			minYear: minDate?.year(),
+			maxYear: maxDate?.year()
+		})
+	)
+	const currentPageAttribute = useMemo(
+		() =>
+			calculatePageAttribute({
+				page,
+				minYear: minDate?.year(),
+				maxYear: maxDate?.year()
+			}),
+		[page, minDate, maxDate]
+	)
+
+	const handleGoToNext = useCallback((): void => {
+		setPage(p => p + ONE)
+	}, [])
+	const handleGoToPrevious = useCallback((): void => {
+		setPage(p => p - ONE)
+	}, [])
+
+	return (
+		<div>
+			<PickersArrowSwitcher
+				// meet style
+				slotProps={{
+					nextIconButton: {
+						sx: slotPropsNextIconButtonSx
+					},
+					previousIconButton: {
+						sx: slotPropsPreviousIconButtonSx
+					}
+				}}
+				nextLabel='next'
+				previousLabel='previous'
+				style={yearPickersArrowSwitcherStyle}
+				//
+				// handle pagination
+				isNextDisabled={currentPageAttribute.isNextDisabled}
+				isPreviousDisabled={currentPageAttribute.isPreviousDisabled}
+				onGoToNext={handleGoToNext}
+				onGoToPrevious={handleGoToPrevious}
+			>
+				{/* HACK: the original header does not provide customize year label, so we insert one here, use opacity:0 to hide MuiPickersCalendarHeader-labelContainer */}
+				<div style={{ marginTop: '18px' }}>{value?.year()}</div>
+			</PickersArrowSwitcher>
+			{
+				/**
+				 * renderDateViewCalendar function comes from the mui-x source code where they used to render yearCalendar
+				 * (https://github.com/mui/mui-x/blob/master/packages/x-date-pickers/src/MobileDateTimePicker/MobileDateTimePicker.tsx)
+				 */
+				renderDateViewCalendar({
+					minDate: dayjs(yearToDayjsInput(currentPageAttribute.startYear)),
+					maxDate: dayjs(yearToDayjsInput(currentPageAttribute.endYear)),
+					value,
+					sx: yearViewSx,
+					...props
+				})
+			}
+		</div>
+	)
+}

--- a/src/components/AhaDatePicker/__tests__/utils.ts
+++ b/src/components/AhaDatePicker/__tests__/utils.ts
@@ -1,0 +1,74 @@
+import { describe } from 'vitest'
+import {
+	calculatePageAttribute,
+	calculateWhichPageShouldDisplay
+} from '../utils'
+
+// YEARS_PER_PAGE = 20
+
+describe('calculateWhichPageShouldDisplay', () => {
+	test('should calculate the correct page number', () => {
+		expect(
+			calculateWhichPageShouldDisplay({
+				valueYear: 2020,
+				todayYear: 2022,
+				minYear: 2000,
+				maxYear: 2030
+			})
+		).toBe(101) // 2020 / 20
+	})
+
+	test('should use default values when necessary', () => {
+		expect(
+			calculateWhichPageShouldDisplay({
+				todayYear: 2022
+			})
+		).toBe(101) // 2022 / 20
+	})
+
+	test('should limit the display year within the allowed range', () => {
+		expect(
+			calculateWhichPageShouldDisplay({
+				valueYear: 1995,
+				todayYear: 2022,
+				minYear: 2000,
+				maxYear: 2030
+			})
+		).toBe(100) // 2000 / 20
+
+		expect(
+			calculateWhichPageShouldDisplay({
+				valueYear: 2055,
+				todayYear: 2022,
+				minYear: 2000,
+				maxYear: 2030
+			})
+		).toBe(101) // 2030 / 20
+	})
+})
+
+describe('calculatePageAttribute', () => {
+	test('should calculate the correct page attributes', () => {
+		const result = calculatePageAttribute({
+			page: 2,
+			minYear: 2000,
+			maxYear: 2015
+		})
+
+		expect(result.startYear).toBe(2000) // 2 * 20 + 1 = 41 , 41 < 2000
+		expect(result.endYear).toBe(2015) // 2000 + 20 - 1 = 2019 > 2015
+		expect(result.isNextDisabled).toBe(true) // endYear (2015) >= maxYear (2015)
+		expect(result.isPreviousDisabled).toBe(true) // startYear (2000) <= minYear (2000)
+	})
+
+	test('should handle default values correctly', () => {
+		const result = calculatePageAttribute({
+			page: 0
+		})
+
+		expect(result.startYear).toBe(1) // 0 * 20 + 1 = 1
+		expect(result.endYear).toBe(20) // 1 + 20 - 1 = 20
+		expect(result.isNextDisabled).toBe(false) // endYear (20) < default maxYear
+		expect(result.isPreviousDisabled).toBe(true) // startYear (1) <= default minYear
+	})
+})

--- a/src/components/AhaDatePicker/index.ts
+++ b/src/components/AhaDatePicker/index.ts
@@ -1,0 +1,2 @@
+// eslint-disable-next-line import/prefer-default-export
+export { default as AhaDatePicker } from './AhaDatePicker'

--- a/src/components/AhaDatePicker/stylesDatePicker.ts
+++ b/src/components/AhaDatePicker/stylesDatePicker.ts
@@ -30,6 +30,8 @@
  * │   └── div(data-testid="sentinelEnd")
  */
 
+export const previousSelectedCssClass = 'App-Previous-Selected'
+
 export const slotPropsPopperSx = {
 	'.MuiPaper-root': {
 		backgroundImage: 'none', // MuiPaper has default gradient, so we need to override it
@@ -83,9 +85,25 @@ export const slotPropsPopperSx = {
 						backgroundColor: '#FFFFFF',
 						color: '#1B1B1B'
 					},
+					':focus': {
+						backgroundColor: '#1B1B1B'
+					},
 
 					'&.MuiPickersDay-today': {
-						borderColor: '#00A3FF'
+						border: 'none'
+					},
+
+					'&.Mui-selected': {
+						backgroundColor: '#00A3FF',
+						color: '#FFFFFF'
+					},
+
+					'&.MuiPickersDay-dayOutsideMonth': {
+						color: '#5D5D5D'
+					},
+
+					[`&.${previousSelectedCssClass}`]: {
+						border: '1px solid #00A3FF'
 					}
 				}
 			}

--- a/src/components/AhaDatePicker/stylesDatePicker.ts
+++ b/src/components/AhaDatePicker/stylesDatePicker.ts
@@ -1,0 +1,125 @@
+/**
+ *  CSS Structure overview
+ *
+ * ├── div(MuiPaper-root)
+ * │   ├── div(MuiPickersPopper-paper)
+ * │   │   ├── div(MuiPickersLayout-root)
+ * │   │   │   ├── div(MuiPickersLayout-toolbar)
+ * │   │   │   │   ├── span - Select date
+ * │   │   │   │   └── div(MuiPickersToolbar-content)
+ * │   │   │   │       └── h4 - Jun, 2023
+ * │   │   │   ├─ div(MuiPickersLayout-contentWrapper)
+ * │   │   │   │    └─ div(MuiDateCalendar-root)
+ * │   │   │   │       ├── div(MuiPickersCalendarHeader-root)
+ * │   │   │   │       │   ├── div(MuiPickersCalendarHeader-labelContainer)
+ * │   │   │   │       │   │   ├── div - June 2023
+ * │   │   │   │       │   │   └── button - switchViewButton
+ * │   │   │   │       │   └── div(MuiPickersArrowSwitcher-root)
+ * │   │   │   │       │        ├── button - ArrowLeftIcon
+ * │   │   │   │       │        └── button - ArrowRightIcon
+ * │   │   │   │       └── div(MuiPickersFadeTransitionGroup-root)
+ * │   │   │   │           └── div
+ * │   │   │   │               └── div
+ * │   │   │   │                   └── div(role="grid")
+ * │   │   │   │                       └── div(MuiDayCalendar-weekContainer)
+ * │   │   │   │                           ├── button(MuiPickersDay) - 28
+ * │   │   │   │                           └── button(MuiPickersDay) - 29
+ * │   │   │   └── div(MuiDialogActions-root)
+ * │   │   │           ├── button - Cancel
+ * │   │   │           └── button - OK
+ * │   └── div(data-testid="sentinelEnd")
+ */
+
+export const slotPropsPopperSx = {
+	'.MuiPaper-root': {
+		backgroundImage: 'none', // MuiPaper has default gradient, so we need to override it
+		backgroundColor: '#1B1B1B',
+
+		// meet style
+		'.MuiPickersLayout-toolbar': {
+			paddingTop: '8px',
+			paddingBottom: '6px',
+			paddingLeft: '26px',
+			paddingRight: '24px'
+		},
+
+		'.MuiPickersCalendarHeader-root': {
+			// make label (June 2023) display in the center (default is on the left)
+			justifyContent: 'center',
+			'.MuiPickersCalendarHeader-labelContainer': {
+				margin: 0,
+				// eslint-disable-next-line @typescript-eslint/no-magic-numbers
+				zIndex: 1 // HACK: greater than the zIndex of the arrowSwitcher, so this one is clickable to switch view
+			},
+
+			// make arrow left and right on each side (default is on the right side)
+			'.MuiPickersArrowSwitcher-root': {
+				position: 'absolute',
+				left: '0',
+				width: '100%',
+				display: 'flex',
+				justifyContent: 'space-between',
+				paddingLeft: '5px',
+				paddingRight: '5px',
+				zIndex: 0 // HACK: smaller than the zIndex of the labelContainer, so labelContainer is clickable to switch view
+			},
+
+			// in our design, we don't need this
+			'.MuiPickersCalendarHeader-switchViewButton': {
+				display: 'none'
+			}
+		},
+
+		'.MuiDayCalendar-slideTransition': {
+			minHeight: '220px',
+
+			'.MuiDayCalendar-weekContainer': {
+				margin: '0',
+
+				'.MuiPickersDay-root': {
+					fontSize: '14px',
+
+					':hover': {
+						backgroundColor: '#FFFFFF',
+						color: '#1B1B1B'
+					},
+
+					'&.MuiPickersDay-today': {
+						borderColor: '#00A3FF'
+					}
+				}
+			}
+		},
+
+		'.MuiPickersLayout-actionBar': {
+			paddingTop: '5px',
+			paddingBottom: '12px',
+
+			// make action button with longer distance
+			'&>:not(:first-of-type)': {
+				marginLeft: '40px'
+			}
+		}
+	}
+}
+
+export const slotPropsTextFieldSx = {
+	'.MuiOutlinedInput-root': {
+		'&.Mui-focused fieldset': {
+			border: '3px solid #FFFFFF'
+		}
+	}
+}
+
+export const slotPropsInputAdornmentSx = {
+	'&': {
+		visibility: 'hidden' // HACK: this is the calendar icon, although we can use disableOpenPicker to hide it, but that will make the calendar lose its position
+	}
+}
+
+export const slotPropsActionBarSx = {
+	button: {
+		textTransform: 'none',
+		color: '#FFFFFF'
+	}
+}

--- a/src/components/AhaDatePicker/stylesYearPicker.ts
+++ b/src/components/AhaDatePicker/stylesYearPicker.ts
@@ -1,0 +1,42 @@
+import type { CSSProperties } from 'react'
+
+export const slotPropsNextIconButtonSx = {
+	marginTop: '10px'
+}
+
+export const slotPropsPreviousIconButtonSx = {
+	marginTop: '10px'
+}
+
+// make arrow left and right on each side (default is on the right side)
+export const yearPickersArrowSwitcherStyle: CSSProperties = {
+	position: 'absolute',
+	left: '0',
+	width: '100%',
+	display: 'flex',
+	justifyContent: 'space-between',
+	paddingLeft: '5px',
+	paddingRight: '5px'
+}
+
+export const yearViewSx = {
+	'.MuiYearCalendar-root': {
+		padding: '0 20px'
+	},
+	'.MuiPickersCalendarHeader-labelContainer': {
+		opacity: 0
+	},
+	'.MuiPickersYear-yearButton': {
+		borderRadius: '2px',
+		height: '26px',
+		width: '65px',
+		'&.Mui-selected': {
+			backgroundColor: '#00A3FF',
+			color: '#FFFFFF'
+		},
+		':hover': {
+			backgroundColor: '#FFFFFF',
+			color: '#1B1B1B'
+		}
+	}
+}

--- a/src/components/AhaDatePicker/utils.ts
+++ b/src/components/AhaDatePicker/utils.ts
@@ -1,0 +1,63 @@
+interface ICalculatePageAttributeReturn {
+	startYear: number
+	endYear: number
+	isNextDisabled: boolean
+	isPreviousDisabled: boolean
+}
+
+const YEARS_PER_PAGE = 20 // 5 rows * 4 columns
+const ONE = 1 // XXX: although this looks unnecessary, we need this to prevent 'no-magic-number' eslint rule
+const SYS_MIN_YEAR = 1
+const SYS_MAX_YEAR = 9999
+
+export const calculateWhichPageShouldDisplay = ({
+	valueYear,
+	todayYear,
+	minYear: userMinYear,
+	maxYear: userMaxYear
+}: {
+	valueYear?: number
+	todayYear: number
+	minYear?: number
+	maxYear?: number
+}): number => {
+	const minYear = Math.max(userMinYear ?? SYS_MIN_YEAR, SYS_MIN_YEAR)
+	const maxYear = Math.min(userMaxYear ?? SYS_MAX_YEAR, SYS_MAX_YEAR)
+
+	let displayYear = valueYear ?? todayYear
+	displayYear = Math.max(displayYear, minYear)
+	displayYear = Math.min(displayYear, maxYear)
+
+	return Math.floor(displayYear / YEARS_PER_PAGE)
+}
+
+export const calculatePageAttribute = ({
+	page,
+	minYear: userMinYear,
+	maxYear: userMaxYear
+}: {
+	page: number
+	minYear?: number
+	maxYear?: number
+}): ICalculatePageAttributeReturn => {
+	const minYear = Math.max(userMinYear ?? SYS_MIN_YEAR, SYS_MIN_YEAR)
+	const maxYear = Math.min(userMaxYear ?? SYS_MAX_YEAR, SYS_MAX_YEAR)
+
+	const startYear = Math.max(page * YEARS_PER_PAGE + ONE, minYear)
+	const endYear = Math.min(startYear + YEARS_PER_PAGE - ONE, maxYear)
+
+	const isNextDisabled = endYear >= maxYear
+	const isPreviousDisabled = startYear <= minYear
+	return { startYear, endYear, isNextDisabled, isPreviousDisabled }
+}
+
+/**
+ * transfer year number to correct dayjs input format
+ * dayjs('1') = 2000 (incorrect)
+ * dayjs('0001') = 0001 (correct)
+ * @param year
+ */
+export const yearToDayjsInput = (year: number): string => {
+	const PAD = 4
+	return year.toString().padStart(PAD, '0')
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,6 +5,8 @@ import { registerSW } from 'virtual:pwa-register'
 import './index.css'
 import muiTheme from './muiTheme'
 import { ThemeProvider as MuiThemeProvider } from '@mui/material'
+import { LocalizationProvider } from '@mui/x-date-pickers'
+import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs'
 
 registerSW()
 
@@ -14,7 +16,9 @@ if (container) {
 	root.render(
 		<StrictMode>
 			<MuiThemeProvider theme={muiTheme}>
-				<App />
+				<LocalizationProvider dateAdapter={AdapterDayjs}>
+					<App />
+				</LocalizationProvider>
 			</MuiThemeProvider>
 		</StrictMode>
 	)

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,8 +1,16 @@
 import type { ReactElement } from 'react'
+import { useCallback, useState } from 'react'
 import Head from '../components/Common/Head'
-import PasswordTextField from '../components/PasswordTextField/PasswordTextField'
+import { PasswordTextField } from '../components/PasswordTextField'
+import { AhaDatePicker } from '../components/AhaDatePicker'
+import type { Dayjs } from 'dayjs'
 
 export default function HomePage(): ReactElement {
+	const [datePickerValue, setDatePickerValue] = useState<Dayjs | null>()
+	const handleDatePickerValueChange = useCallback((value: Dayjs | null) => {
+		setDatePickerValue(value)
+	}, [])
+
 	return (
 		<>
 			<Head title='AHA Front-End Assignment Exam 1' />
@@ -10,8 +18,27 @@ export default function HomePage(): ReactElement {
 				<div className='flex justify-center p-2'>
 					<h1 className='text-2xl'>AHA Front-End Assignment Exam 1</h1>
 				</div>
-				<div className='mt-10 flex w-1/2 justify-center'>
-					<PasswordTextField />
+				<div className='flex'>
+					<div className='mt-10 flex h-screen w-1/2 justify-center'>
+						<div>
+							<h2 className='m-10 pr-8 text-center text-xl'>Password Input</h2>
+							<PasswordTextField />
+						</div>
+					</div>
+					<div className='mt-10 flex h-screen w-1/2 justify-center'>
+						<div>
+							<h2 className='m-10 pr-8 text-center text-xl'>Date Picker</h2>
+							<AhaDatePicker
+								defaultValue={datePickerValue}
+								onChange={handleDatePickerValueChange}
+								slotProps={{
+									textField: {
+										label: 'Birthday'
+									}
+								}}
+							/>
+						</div>
+					</div>
 				</div>
 			</div>
 		</>


### PR DESCRIPTION
# Context

In this pull request, I continue to finish the DatePicker's step 2, year Calendar
because our Aha styled year calendar use pagination to change year page, instead of using scroll like MUI-X,
we need to create our own customized Year Calendar to do this

# Changes

1. customized ui 
2. add customized PickersArrowSwitcher (which is the header of calendar, include arrow and label like  " < June, 2023 > " ) 

# Screenshot 


https://github.com/benqqqq/aha-fe-assignment/assets/11547758/2c662976-a9e6-4bad-8d5a-6275c465b8f2


